### PR TITLE
Updated POM to inherit dependencies from THREDDS project, bumped THREDDS version to 4.3.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <thredds.version>4.3.15</thredds.version>
   </properties>
   
   <repositories>
@@ -37,77 +38,62 @@
 	</repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>edu.ucar</groupId>
+        <artifactId>thredds-parent</artifactId>
+        <version>${thredds.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.5</version>
       <scope>test</scope>
     </dependency>
 	<dependency>
-	  <groupId>jdom</groupId>
+	  <groupId>org.jdom</groupId>
 	  <artifactId>jdom</artifactId>
-	  <version>1.1</version>
 	</dependency>
 	<dependency>
 	  <groupId>joda-time</groupId>
 	  <artifactId>joda-time</artifactId>
-	  <version>2.0</version>
 	</dependency>
 	<dependency>
 	  <groupId>log4j</groupId>
 	  <artifactId>log4j</artifactId>
-	  <version>1.2.16</version>
 	</dependency>
 	<dependency>
 	  <groupId>edu.ucar</groupId>
 	  <artifactId>netcdf</artifactId>
-	  <version>4.3.10</version>
 	</dependency>
 	<dependency>
-	  <groupId>org.apache.tomcat</groupId>
+	  <groupId>javax.servlet</groupId>
 	  <artifactId>servlet-api</artifactId>
-	  <version>6.0.35</version>
+	  <scope>provided</scope>
 	</dependency>
 	<dependency>
 	  <groupId>org.slf4j</groupId>
 	  <artifactId>slf4j-api</artifactId>
-	  <version>1.6.4</version>
-	</dependency>
-	<dependency>
-	  <groupId>org.slf4j</groupId>
-	  <artifactId>slf4j-log4j12</artifactId>
-	  <version>1.6.4</version>
 	</dependency>
 	<dependency>
 	  <groupId>org.springframework</groupId>
-	  <artifactId>spring-context</artifactId>
-	  <version>3.0.5.RELEASE</version>
-	</dependency>
-	<dependency>
-	  <groupId>org.springframework</groupId>
-	  <artifactId>spring-core</artifactId>
-	  <version>3.0.5.RELEASE</version>
-	</dependency>
-	<dependency>
-	  <groupId>org.springframework</groupId>
-	  <artifactId>spring-web</artifactId>
-	  <version>3.0.5.RELEASE</version>
-	</dependency>
+      <artifactId>spring-context</artifactId>
+    </dependency>
 	<dependency>
 	  <groupId>org.springframework</groupId>
 	  <artifactId>spring-webmvc</artifactId>
-	  <version>3.0.5.RELEASE</version>
-	</dependency>
-	<dependency>
-	  <groupId>edu.ucar</groupId>
-	  <artifactId>visadCdm</artifactId>
-	  <version>4.3.10</version>
 	</dependency>
 	<dependency>
 	  <groupId>edu.ucar</groupId>
 	  <artifactId>tds</artifactId>
-	  <version>4.3.10</version>
+      <classifier>classes</classifier>
+	  <scope>provided</scope>
 	</dependency>
   </dependencies>
   


### PR DESCRIPTION
POM was updated to inherit dependencies form THREDDS project using dependency managment and import scope  with thredds-parent pom.   Some dependencies were modified to use groupId and artificatId consistent with those in thredds-parent pom.  This change will guarantee that ncSOS is compiled against the same jars used in THREDDS.  It also has the benefit that ncSOS will not introduce duplicate jars if a maven war overlay is used to inject nsSOS into to THREDDS.
