### PR TITLE
Set Java source and target versions in pom.xml (avoid compiler errors)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,15 @@
   
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>    
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.7</version>
         <executions>


### PR DESCRIPTION
I was getting complier errors in Eclipse about `@Override` annotations on methods implementing interface methods. Explicitly setting the Java source version to 1.6 (same as THREDDS 4.3) solves this.
